### PR TITLE
DGIR-39: Remove unnecessary logger declaration

### DIFF
--- a/src/Commands/PublishUnpublishCollections.php
+++ b/src/Commands/PublishUnpublishCollections.php
@@ -36,13 +36,6 @@ class PublishUnpublishCollections extends DrushCommands {
   protected $utils;
 
   /**
-   * Logging service.
-   *
-   * @var \Psr\Log\LoggerInterface
-   */
-  protected $logger;
-
-  /**
    * Constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager


### PR DESCRIPTION
Declaring logger again which is already defined in the parent class will cause issues when bringing up the environment. 