### PR TITLE
[DGI9-407] update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "islandora/islandora": "^2",
         "discoverygarden/update-helper": "^1",
-        "discoverygarden/dgi_standard_derivative_examiner": "^1"
+        "discoverygarden/dgi_standard_derivative_examiner": "^1.2"
     },
     "extra": {
         "drush": {


### PR DESCRIPTION
Dependent on discoverygarden/dgi_standard_derivative_examiner#10, for the new ExaminerInterface