### PR TITLE
DGI9-617: Fix up logger of user switching.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "extra": {
         "drush": {
             "services": {
+                "drush.11.6-12.5.yml": ">=11.6",
                 "drush.10.services.yml": "^10 || ^11"
             }
         }

--- a/drush.10.services.yml
+++ b/drush.10.services.yml
@@ -28,6 +28,7 @@ services:
     arguments:
       - '@account_switcher'
       - '@entity_type.manager'
+      - '@logger.islandora_drush_utils'
     tags:
       - name: drush.command
   islandora_drush_utils.command.user_wrapping_alterer:

--- a/drush.11.6-12.5.yml
+++ b/drush.11.6-12.5.yml
@@ -1,0 +1,6 @@
+---
+# XXX: Command files are expected to make use of newer methods of instantiation,
+# such as:
+# - create() method as of Drush 11.6; or,
+# - autowiring as of Drush 12.5
+services: {}

--- a/islandora_drush_utils.module
+++ b/islandora_drush_utils.module
@@ -8,7 +8,7 @@
 /**
  * Implements hook_batch_alter().
  */
-function islandora_drush_utils_batch_alter(&$batch) {
+function islandora_drush_utils_batch_alter(array &$batch) : void {
   // Better preservation messsaging.
   foreach ($batch['sets'] as &$set) {
     if (!isset($set['operations'])) {
@@ -59,24 +59,24 @@ function islandora_drush_utils_batch_alter(&$batch) {
     if (is_string($callable)) {
       return trim($callable);
     }
-    elseif (is_array($callable)) {
+
+    if (is_array($callable)) {
       if (is_object($callable[0])) {
         return sprintf("(%s instance)::%s", get_class($callable[0]),
           trim($callable[1]));
       }
-      else {
-        return sprintf("%s::%s", trim($callable[0]), trim($callable[1]));
-      }
+
+      return sprintf("%s::%s", trim($callable[0]), trim($callable[1]));
     }
-    elseif ($callable instanceof Closure) {
+
+    if ($callable instanceof Closure) {
       return 'closure';
     }
-    else {
-      return 'unknown';
-    }
+
+    return 'unknown';
   };
 
-  $wrap_op = function ($op) use ($user, $logger, $namer) {
+  $wrap_op = static function ($op) use ($user, $logger, $namer) {
     $func = reset($op);
     if ($func !== '_islandora_drush_utils_user_wrapped_batch_op') {
       $logger->debug('Wrapping @func with @wrapper to maintain the user (@uid).',
@@ -93,9 +93,8 @@ function islandora_drush_utils_batch_alter(&$batch) {
         ],
       ];
     }
-    else {
-      return $op;
-    }
+
+    return $op;
   };
 
   foreach ($batch['sets'] as &$set) {
@@ -108,7 +107,7 @@ function islandora_drush_utils_batch_alter(&$batch) {
 /**
  * Wrap batch op with user.
  */
-function _islandora_drush_utils_user_wrapped_batch_op($id, $info, &$context) {
+function _islandora_drush_utils_user_wrapped_batch_op(int|string $id, array $info, array &$context) {
   $switcher = \Drupal::service('account_switcher');
   try {
     $user = \Drupal::service('entity_type.manager')

--- a/src/Drush/Commands/UserWrapperCommands.php
+++ b/src/Drush/Commands/UserWrapperCommands.php
@@ -9,10 +9,13 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountSwitcherInterface;
+use Drush\Commands\AutowireTrait;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -23,9 +26,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * "@islandora_drush_utils-user-wrap" annotation to use it where we want
  * to.
  */
-class UserWrapperCommands implements LoggerAwareInterface, ContainerInjectionInterface {
+class UserWrapperCommands implements ContainerInjectionInterface {
 
-  use LoggerAwareTrait;
+  use AutowireTrait;
 
   /**
    * The user to which we will switch.
@@ -42,6 +45,8 @@ class UserWrapperCommands implements LoggerAwareInterface, ContainerInjectionInt
   public function __construct(
     protected AccountSwitcherInterface $switcher,
     protected EntityTypeManagerInterface $entityTypeManager,
+    #[Autowire(service: 'logger.islandora_drush_utils')]
+    protected LoggerInterface $logger,
     protected $debug = FALSE,
   ) {
   }
@@ -53,6 +58,7 @@ class UserWrapperCommands implements LoggerAwareInterface, ContainerInjectionInt
     return new static(
       $container->get('account_switcher'),
       $container->get('entity_type.manager'),
+      $container->get('@logger.islandora_drush_utils'),
       FALSE,
     );
   }

--- a/src/Drush/Commands/UserWrapperCommands.php
+++ b/src/Drush/Commands/UserWrapperCommands.php
@@ -56,7 +56,7 @@ class UserWrapperCommands implements ContainerInjectionInterface {
     return new static(
       $container->get('account_switcher'),
       $container->get('entity_type.manager'),
-      $container->get('@logger.islandora_drush_utils'),
+      $container->get('logger.islandora_drush_utils'),
       FALSE,
     );
   }

--- a/src/Drush/Commands/UserWrapperCommands.php
+++ b/src/Drush/Commands/UserWrapperCommands.php
@@ -10,8 +10,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountSwitcherInterface;
 use Drush\Commands\AutowireTrait;
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Added Drush service mapping for versions 11.6 and newer, including a compatibility file for 11.6–12.5.
* Refactor
  * Migrated Drush command to modern dependency injection with a dedicated logger for clearer, more consistent logging.
  * Tightened type hints and batch hook signatures for safer, more predictable execution.
  * Simplified internal logic to improve maintainability without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->