### PR TITLE
MRDI-16: Add command to update field_display_hints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,33 @@ There are a few related commands:
 
 Before Drush 9, there was a "--user" option that could be used to run commands as other users. Here, a new  "@islandora_drush_utils-user-wrap" annotation is provided, which can be used to allow the --user option in commands.
 
+### Display hint updater
+
+When rolling out additional viewers, depending on how the front end is
+configured, it may be necessary to update the display hints for nodes.
+
+The provided Drush commands will:
+1. `islandora_drush_utils:display-hint-feeder` - Returns all nodes with any
+specified taxonomy term URI(s) representing model(s) to update within
+`field_model`. Defaults to `https://schema.org/Book`.
+2. `islandora_drush_utils:update-display-hints` - Update all nodes passed with a
+specified taxonomy term URI in a replacement scenario. Defaults to
+`https://projectmirador.org`.
+
+To invoke the updater command:
+```bash
+drush islandora_drush_utils:display-hint-feeder --user=1 --term-uris='https://schema.org/Book' > nodes.csv
+drush islandora_drush_utils:update-display-hints --user=1 --term-uri='https://projectmirador.org' < nodes.csv
+```
+
+An alternative, more optimal approach would be to use GNU Parallel with
+two processes each processing 100 items at a time:
+
+```bash
+drush islandora_drush_utils:display-hint-feeder --user=1 --term-uris='https://schema.org/Book' | parallel --pipe --max-args 100 -j2 drush islandora_drush_utils:update-display-hints --user=1 --term-uri='https://projectmirador.org'
+```
+
+
 ## Troubleshooting/Issues
 
 Having problems or solved a problem? Contact [discoverygarden](http://support.discoverygarden.ca).

--- a/drush.10.services.yml
+++ b/drush.10.services.yml
@@ -59,3 +59,10 @@ services:
       - '@queue'
     tags:
       - name: drush.command
+  islandora_drush_utils.display_hint_updater:
+    class: \Drupal\islandora_drush_utils\Drush\Commands\UpdateDisplayHints
+    arguments:
+      - '@entity_type.manager'
+      - '@messenger'
+    tags:
+      - name: drush.command

--- a/src/Drush/Commands/UpdateDisplayHints.php
+++ b/src/Drush/Commands/UpdateDisplayHints.php
@@ -57,7 +57,7 @@ class UpdateDisplayHints extends DrushCommands {
       ->execute();
 
     if (empty($terms)) {
-      $this->messenger->addError(t('No terms found with URIs: @uris', [
+      $this->messenger->addError($this->t('No terms found with URIs: @uris', [
         '@uris' => implode(', ', $uris),
       ]));
       return;

--- a/src/Drush/Commands/UpdateDisplayHints.php
+++ b/src/Drush/Commands/UpdateDisplayHints.php
@@ -20,6 +20,8 @@ class UpdateDisplayHints extends DrushCommands {
   use DependencySerializationTrait;
 
   public const CHUNK_SIZE = 100;
+  public const MODEL_URI = 'https://schema.org/Book';
+  public const DISPLAY_HINT_URI = 'https://projectmirador.org';
 
   /**
    * Construct.
@@ -40,7 +42,7 @@ class UpdateDisplayHints extends DrushCommands {
   #[CLI\Option(name: 'term-uris', description: 'Comma separated list of Islandora Model term URIs to target.')]
   public function displayHintFeeder(
     array $options = [
-      'term-uris' => 'https://schema.org/Book',
+      'term-uris' => self::MODEL_URI,
     ],
   ) : void {
     $uris = array_map('trim', explode(',', $options['term-uris']));
@@ -84,7 +86,7 @@ class UpdateDisplayHints extends DrushCommands {
   public function updateDisplayHints(
     string $nids,
     array $options = [
-      'term-uri' => 'https://projectmirador.org',
+      'term-uri' => self::DISPLAY_HINT_URI,
     ],
   ) : void {
     $termStorage = $this->entityTypeManager->getStorage('taxonomy_term');

--- a/src/Drush/Commands/UpdateDisplayHints.php
+++ b/src/Drush/Commands/UpdateDisplayHints.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Drupal\islandora_drush_utils\Drush\Commands;
+
+use Drupal\Core\Batch\BatchBuilder;
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drush\Attributes as CLI;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Commands to update display hints en masse.
+ */
+class UpdateDisplayHints extends DrushCommands {
+
+  use AutowireTrait;
+  use DependencySerializationTrait;
+
+  public const CHUNK_SIZE = 100;
+
+  /**
+   * Construct.
+   */
+  public function __construct(
+    #[Autowire(service: 'entity_type.manager')]
+    protected EntityTypeManagerInterface $entityTypeManager,
+    #[Autowire(service: 'messenger')]
+    protected MessengerInterface $messenger,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Feeder command to grab NIDs of items to update.
+   */
+  #[CLI\Command(name: 'islandora_drush_utils:display-hint-feeder')]
+  #[CLI\Option(name: 'term-uris', description: 'Comma separated list of Islandora Model term URIs to target.')]
+  public function displayHintFeeder(
+    array $options = [
+      'term-uris' => 'https://schema.org/Book',
+    ],
+  ) : void {
+    $uris = array_map('trim', explode(',', $options['term-uris']));
+
+    $termStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $terms = $termStorage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('field_external_uri', $uris, 'IN')
+      ->condition('vid', 'islandora_models')
+      ->execute();
+
+    if (empty($terms)) {
+      $this->messenger->addError(t('No terms found with URIs: @uris', [
+        '@uris' => implode(', ', $uris),
+      ]));
+      return;
+    }
+
+    $termIds = array_keys($terms);
+    $nodeStorage = $this->entityTypeManager->getStorage('node');
+
+    $nids = $nodeStorage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('field_model', $termIds, 'IN')
+      ->execute();
+
+    if (empty($nids)) {
+      $this->messenger->addError(t('No applicable nodes found.'));
+      return;
+    }
+
+    $this->output()->writeln(implode(',', $nids));
+  }
+
+  /**
+   * Feeder command to grab NIDs of items to update.
+   */
+  #[CLI\Command(name: 'islandora_drush_utils:update-display-hints')]
+  #[CLI\Argument(name: 'nids', description: 'Comma separated list of NIDs to update.')]
+  #[CLI\Option(name: 'term-uri', description: 'Islandora Display term URI to update field_display_hints to.')]
+  public function updateDisplayHints(
+    string $nids,
+    array $options = [
+      'term-uri' => 'https://projectmirador.org',
+    ],
+  ) : void {
+    $termStorage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $terms = $termStorage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('field_external_uri', $options['term-uri'])
+      ->condition('vid', 'islandora_display')
+      ->execute();
+
+    if (empty($terms)) {
+      $this->messenger->addError(t('No terms found with URI: @uri', [
+        '@uri' => reset($options['term-uri']),
+      ]));
+      return;
+    }
+
+    $termId = reset($terms);
+    $nodeIds = array_map('trim', explode(',', $nids));
+
+    $batch = new BatchBuilder();
+    $batch->setTitle('Updating display hints.')
+      ->setFinishCallback([$this, 'batchFinished'])
+      ->setInitMessage('Beginning update of field_display_hints.')
+      ->setErrorMessage('An error occurred during update of field_display_hints.');
+
+    $chunks = array_chunk($nodeIds, self::CHUNK_SIZE);
+    foreach ($chunks as $batchId => $chunk) {
+      $this->messenger->addMessage(t('Queuing batch @batchId', ['@batchId' => $batchId]));
+      $batch->addOperation([$this, 'processBatch'], [$chunk, $termId, $batchId, count($nodeIds)]);
+    }
+
+    drush_op('batch_set', $batch->toArray());
+    drush_op('drush_backend_batch_process');
+  }
+
+  public function processBatch(array $chunk, int $termId, int $batchId, int $nodeCount, array &$context): void {
+    if (!isset($context['sandbox']['progress'])) {
+      $context['sandbox']['progress'] = 0;
+      $context['sandbox']['max'] = $nodeCount;
+    }
+
+    if (!isset($context['sandbox']['updated'])) {
+      $context['results']['updated'] = 0;
+      $context['results']['progress'] = 0;
+    }
+
+    $context['results']['progress'] += count($chunk);
+
+    $context['message'] = t('Processing batch @batchId. Progress: @progress of @nodeCount.', [
+      '@batchId' => $batchId,
+      '@progress' => $context['results']['progress'],
+      '@nodeCount' => $context['sandbox']['max'],
+    ]);
+
+    foreach ($chunk as $node) {
+      $node = $this->entityTypeManager->getStorage('node')->load($node);
+      $node->set('field_display_hints', $termId);
+      $node->save();
+      $context['results']['updated']++;
+    }
+  }
+
+  public function batchFinished(bool $success, array $results, array $operations, string $elapsed): void {
+    if ($success) {
+      $this->messenger->addMessage(t('Updated display hints for @count objects. Time: @elapsed', [
+        '@count' => $results['updated'],
+        '@elapsed' => $elapsed,
+      ]));
+    } else {
+      $error_operation = reset($operations);
+      if ($error_operation) {
+        $this->messenger->addError(t('An error occurred while processing @operation.', [
+          '@operation' => $error_operation[0],
+        ]));
+      }
+    }
+
+  }
+
+}

--- a/src/Drush/Commands/UpdateDisplayHints.php
+++ b/src/Drush/Commands/UpdateDisplayHints.php
@@ -116,20 +116,19 @@ class UpdateDisplayHints extends DrushCommands {
 
     $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple(array_filter(array_map('trim', $nodeIds)));
     foreach ($nodes as $node) {
-  foreach ($nodes as $node) {
-    if (!$options['dry-run']) {
-      $node->set('field_display_hints', $termId);
-      $node->save();
-      $this->messenger->addMessage($this->t('Updated display hints for @nid.', [
-        '@nid' => $node->id(),
-      ]));
+      if (!$options['dry-run']) {
+        $node->set('field_display_hints', $termId);
+        $node->save();
+        $this->messenger->addMessage($this->t('Updated display hints for @nid.', [
+          '@nid' => $node->id(),
+        ]));
+      }
+      else {
+        $this->messenger->addMessage($this->t('Would update display hints for @nid (dry run).', [
+          '@nid' => $node->id(),
+        ]));
+      }
     }
-    else {
-      $this->messenger->addMessage($this->t('Would update display hints for @nid (dry run).', [
-        '@nid' => $node->id(),
-      ]));
-    }
-  }
   }
 
 }

--- a/src/Drush/Commands/UpdateDisplayHints.php
+++ b/src/Drush/Commands/UpdateDisplayHints.php
@@ -146,8 +146,8 @@ class UpdateDisplayHints extends DrushCommands {
       '@nodeCount' => $context['sandbox']['max'],
     ]);
 
-    foreach ($chunk as $node) {
-      $node = $this->entityTypeManager->getStorage('node')->load($node);
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($chunk);
+    foreach ($nodes as $node) {
       $node->set('field_display_hints', $termId);
       $node->save();
       $context['results']['updated']++;

--- a/src/Drush/Commands/UpdateDisplayHints.php
+++ b/src/Drush/Commands/UpdateDisplayHints.php
@@ -116,14 +116,20 @@ class UpdateDisplayHints extends DrushCommands {
 
     $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple(array_filter(array_map('trim', $nodeIds)));
     foreach ($nodes as $node) {
+  foreach ($nodes as $node) {
+    if (!$options['dry-run']) {
+      $node->set('field_display_hints', $termId);
+      $node->save();
       $this->messenger->addMessage($this->t('Updated display hints for @nid.', [
         '@nid' => $node->id(),
       ]));
-      if (!$options['dry-run']) {
-        $node->set('field_display_hints', $termId);
-        $node->save();
-      }
     }
+    else {
+      $this->messenger->addMessage($this->t('Would update display hints for @nid (dry run).', [
+        '@nid' => $node->id(),
+      ]));
+    }
+  }
   }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new command-line functionality enabling bulk management of display hints.
	- Added commands to retrieve content identifiers based on taxonomy criteria and update display settings efficiently.
	- Enhanced error handling and notifications to ensure clear user feedback during operations.
	- New section in the README detailing the usage of the new Drush commands for managing display hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->