### PR TITLE
DGI9-617: Fix application of alterers.

### DIFF
--- a/drush.10.services.yml
+++ b/drush.10.services.yml
@@ -32,7 +32,7 @@ services:
     tags:
       - name: drush.command
   islandora_drush_utils.command.user_wrapping_alterer:
-    class: \Drupal\islandora_drush_utils\Drush\CommandInfoAlterers\UserWrappingAlterer
+    class: \Drupal\islandora_drush_utils\Drush\CommandInfoAlterers\UserWrappingCommandInfoAlterer
     tags:
       - name: drush.command_info_alterer
     arguments:

--- a/src/Drush/CommandInfoAlterers/UserWrappingCommandInfoAlterer.php
+++ b/src/Drush/CommandInfoAlterers/UserWrappingCommandInfoAlterer.php
@@ -8,7 +8,6 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drush\Commands\AutowireTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Re-create the global --user option.

--- a/src/Drush/CommandInfoAlterers/UserWrappingCommandInfoAlterer.php
+++ b/src/Drush/CommandInfoAlterers/UserWrappingCommandInfoAlterer.php
@@ -4,7 +4,11 @@ namespace Drupal\islandora_drush_utils\Drush\CommandInfoAlterers;
 
 use Consolidation\AnnotatedCommand\CommandInfoAltererInterface;
 use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drush\Commands\AutowireTrait;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Re-create the global --user option.
@@ -12,7 +16,9 @@ use Psr\Log\LoggerInterface;
  * XXX: Drush 9 dropped it; however, we require this option for various
  * commands.
  */
-class UserWrappingAlterer implements CommandInfoAltererInterface {
+class UserWrappingCommandInfoAlterer implements CommandInfoAltererInterface, ContainerInjectionInterface {
+
+  use AutowireTrait;
 
   /**
    * The annotation we use to handle user swapping.
@@ -30,11 +36,18 @@ class UserWrappingAlterer implements CommandInfoAltererInterface {
   ];
 
   /**
+   * Manual toggle, for debugging alterer.
+   *
+   * @var bool
+   */
+  protected bool $debug = FALSE;
+
+  /**
    * Constructor.
    */
   public function __construct(
+    #[Autowire(service: 'logger.islandora_drush_utils')]
     protected LoggerInterface $logger,
-    protected $debug = FALSE,
   ) {
     // No-op.
   }

--- a/src/Drush/CommandInfoAlterers/UserWrappingCommandInfoAlterer.php
+++ b/src/Drush/CommandInfoAlterers/UserWrappingCommandInfoAlterer.php
@@ -30,7 +30,6 @@ class UserWrappingCommandInfoAlterer implements CommandInfoAltererInterface, Con
   const COMMANDS = [
     'content-sync:import',
     'content-sync:export',
-    'batch:process',
     'migrate:rollback',
   ];
 


### PR DESCRIPTION
#31 would've resulting in the legacy service alterer definitions no longer being used, and drush caching possibly leading to thinking things were working when they were not.

Addressed the couple of issues with the newer discovery mechanisms and service instantation therewith.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed and reorganized an internal command utility and updated its dependency injection wiring to improve maintainability; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->