### PR TITLE
D11-9 / D11-11: Avoid setting `$this->logger` directly.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         "discoverygarden/update-helper": "^1",
         "discoverygarden/dgi_standard_derivative_examiner": "^1.2 || ^2"
     },
+    "conflict": {
+        "drush/drush": "<13"
+    },
     "extra": {
         "drush": {
             "services": {

--- a/src/Drush/Commands/PublishUnpublishCollections.php
+++ b/src/Drush/Commands/PublishUnpublishCollections.php
@@ -48,7 +48,7 @@ class PublishUnpublishCollections extends DrushCommands {
   public function __construct(EntityTypeManagerInterface $entity_type_manager, IslandoraUtils $islandora_utils, LoggerInterface $logger) {
     $this->storage = $entity_type_manager;
     $this->utils = $islandora_utils;
-    $this->logger = $logger;
+    $this->logger()?->add('islandora_drush_utils', $logger);
   }
 
   /**

--- a/src/Drush/Commands/Sec873DrushCommands.php
+++ b/src/Drush/Commands/Sec873DrushCommands.php
@@ -64,7 +64,7 @@ class Sec873DrushCommands extends DrushCommands {
     protected QueueFactory $queueFactory,
   ) {
     parent::__construct();
-    $this->setLogger($logger);
+    $this->logger()?->add('islandora_drush_utils.sec_873', $logger);
   }
 
   /**


### PR DESCRIPTION
Drush 13 introduced assertions, expecting the use of a "logger manager".

See: https://github.com/drush-ops/drush/pull/5022

Should possibly bump things up to be more strongly dependent on Drush 13, to avoid things these running in Drush 12 environments?