### PR TITLE
[UI-385] rename file/class so Drush can find it

### DIFF
--- a/drush.10.services.yml
+++ b/drush.10.services.yml
@@ -1,7 +1,7 @@
 ---
 services:
   islandora_drush_utils.deleter:
-    class: \Drupal\islandora_drush_utils\Drush\Commands\Deleter
+    class: \Drupal\islandora_drush_utils\Drush\Commands\DeleterDrushCommands
     arguments:
       - '@entity_type.manager'
       - '@queue'
@@ -10,14 +10,14 @@ services:
     tags:
       - name: drush.command
   islandora_drush_utils.rederiver:
-    class: \Drupal\islandora_drush_utils\Drush\Commands\Rederive
+    class: \Drupal\islandora_drush_utils\Drush\Commands\RederiveDrushCommands
     arguments:
       - '@islandora.utils'
       - '@entity_type.manager'
     tags:
       - name: drush.command
   islandora_drush_utils.rederive_thumbnails:
-    class: \Drupal\islandora_drush_utils\Drush\Commands\GenerateThumbnails
+    class: \Drupal\islandora_drush_utils\Drush\Commands\GenerateThumbnailsDrushCommands
     arguments:
       - '@entity_type.manager'
       - '@database'
@@ -39,7 +39,7 @@ services:
       - '@logger.islandora_drush_utils'
       - false
   islandora_drush_utils.null_child_weight_updater:
-    class: \Drupal\islandora_drush_utils\Drush\Commands\NullChildWeight
+    class: \Drupal\islandora_drush_utils\Drush\Commands\NullChildWeightDrushCommands
     arguments:
       - '@entity_type.manager'
       - '@database'
@@ -47,7 +47,7 @@ services:
     tags:
       - name: drush.command
   islandora_drush_utils.bulk_publish_unpublish:
-    class: \Drupal\islandora_drush_utils\Drush\Commands\PublishUnpublishCollections
+    class: \Drupal\islandora_drush_utils\Drush\Commands\PublishUnpublishCollectionsDrushCommands
     arguments:
       - '@entity_type.manager'
       - '@islandora.utils'
@@ -55,13 +55,13 @@ services:
     tags:
       - { name: drush.command }
   islandora_drush_utils.rebuild_oai:
-    class: \Drupal\islandora_drush_utils\Drush\Commands\RebuildOaiEntries
+    class: \Drupal\islandora_drush_utils\Drush\Commands\RebuildOaiEntriesDrushCommands
     arguments:
       - '@queue'
     tags:
       - name: drush.command
   islandora_drush_utils.display_hint_updater:
-    class: \Drupal\islandora_drush_utils\Drush\Commands\UpdateDisplayHints
+    class: \Drupal\islandora_drush_utils\Drush\Commands\UpdateDisplayHintsDrushCommands
     arguments:
       - '@entity_type.manager'
       - '@messenger'

--- a/src/Drush/Commands/DeleterDrushCommands.php
+++ b/src/Drush/Commands/DeleterDrushCommands.php
@@ -19,9 +19,9 @@ use Drush\Commands\DrushCommands;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Deleter service, to recursively delete.
+ * DeleterDrushCommands service, to recursively delete.
  */
-class Deleter extends DrushCommands implements ContainerInjectionInterface {
+class DeleterDrushCommands extends DrushCommands implements ContainerInjectionInterface {
 
   use DependencySerializationTrait {
     __sleep as traitSleep;

--- a/src/Drush/Commands/GenerateThumbnailsDrushCommands.php
+++ b/src/Drush/Commands/GenerateThumbnailsDrushCommands.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Drush command to rederive thumbnails.
  */
-class GenerateThumbnails extends DrushCommands implements ContainerInjectionInterface {
+class GenerateThumbnailsDrushCommands extends DrushCommands implements ContainerInjectionInterface {
 
   use StringTranslationTrait;
   use NodeIdParsingTrait;

--- a/src/Drush/Commands/NullChildWeightDrushCommands.php
+++ b/src/Drush/Commands/NullChildWeightDrushCommands.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Drush command to identify/update nodes with a mix of values in field_weight.
  */
-class NullChildWeight extends DrushCommands implements ContainerInjectionInterface {
+class NullChildWeightDrushCommands extends DrushCommands implements ContainerInjectionInterface {
 
   use DependencySerializationTrait;
   use StringTranslationTrait;

--- a/src/Drush/Commands/PublishUnpublishCollectionsDrushCommands.php
+++ b/src/Drush/Commands/PublishUnpublishCollectionsDrushCommands.php
@@ -16,7 +16,7 @@ use Psr\Log\LoggerInterface;
  * of given collection nids.
  * They do not affect the actual collection node.
  */
-class PublishUnpublishCollections extends DrushCommands {
+class PublishUnpublishCollectionsDrushCommands extends DrushCommands {
 
   use DependencySerializationTrait;
   use StringTranslationTrait;

--- a/src/Drush/Commands/RebuildOaiEntriesDrushCommands.php
+++ b/src/Drush/Commands/RebuildOaiEntriesDrushCommands.php
@@ -8,11 +8,11 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drush\Commands\DrushCommands;
 
 /**
- * RebuildOaiEntries commands.
+ * RebuildOaiEntriesDrushCommands commands.
  *
  * These commands rebuild the OAI entries and consume them.
  */
-class RebuildOaiEntries extends DrushCommands {
+class RebuildOaiEntriesDrushCommands extends DrushCommands {
 
   use DependencySerializationTrait;
   use StringTranslationTrait;

--- a/src/Drush/Commands/RederiveDrushCommands.php
+++ b/src/Drush/Commands/RederiveDrushCommands.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Drush command implementation.
  */
-class Rederive extends DrushCommands implements ContainerInjectionInterface {
+class RederiveDrushCommands extends DrushCommands implements ContainerInjectionInterface {
 
   use DependencySerializationTrait;
   use StringTranslationTrait;

--- a/src/Drush/Commands/UpdateDisplayHintsDrushCommands.php
+++ b/src/Drush/Commands/UpdateDisplayHintsDrushCommands.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 /**
  * Commands to update display hints en masse.
  */
-class UpdateDisplayHints extends DrushCommands {
+class UpdateDisplayHintsDrushCommands extends DrushCommands {
 
   use AutowireTrait;
   use DependencySerializationTrait;


### PR DESCRIPTION
As noted in the last bullet point in https://www.drush.org/13.x/commands/#auto-discovered-commands-psr4:
Such commands are auto-discovered by their class PSR4 namespace and class/file name suffix. Drush will auto-discover commands if:

- The commands class is PSR4 auto-loadable.
- The commands class namespace, relative to base namespace, is Drush\Commands.
- The class and file name ends with *Commands, e.g. FooCommands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed internal command classes to a consistent naming convention (added "DrushCommands" suffix).
  * No changes to functionality or user-facing behavior; existing commands continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->