### PR TITLE
DGI9-470: Allow for `--user` option to be required.

### DIFF
--- a/src/Drush/Commands/GenerateThumbnailsDrushCommands.php
+++ b/src/Drush/Commands/GenerateThumbnailsDrushCommands.php
@@ -60,7 +60,7 @@ class GenerateThumbnailsDrushCommands extends DrushCommands implements Container
    * @command islandora_drush_utils:rederive_thumbnails
    * @aliases idu:rtn,rtn
    *
-   * @islandora-drush-utils-user-wrap
+   * @islandora-drush-utils-required-user-wrap
    */
   public function rederive(
     array $options = [

--- a/src/Drush/Commands/RederiveDrushCommands.php
+++ b/src/Drush/Commands/RederiveDrushCommands.php
@@ -50,7 +50,7 @@ class RederiveDrushCommands extends DrushCommands implements ContainerInjectionI
    * @command islandora_drush_utils:rederive
    * @aliases islandora_drush_utils:r,idu:r
    *
-   * @islandora-drush-utils-user-wrap
+   * @islandora-drush-utils-required-user-wrap
    */
   public function rederive(
     array $options = [

--- a/src/Drush/Commands/UserWrapperCommands.php
+++ b/src/Drush/Commands/UserWrapperCommands.php
@@ -98,7 +98,7 @@ class UserWrapperCommands implements ContainerInjectionInterface {
   }
 
   /**
-   * Add the option to the command.
+   * Add the option to the command, when the option is required.
    *
    * @hook option @islandora-drush-utils-required-user-wrap
    */
@@ -163,7 +163,7 @@ class UserWrapperCommands implements ContainerInjectionInterface {
   }
 
   /**
-   * Ensure the required user provided is valid.
+   * Ensure the required user provided is valid, when the option is required.
    *
    * @hook validate @islandora-drush-utils-required-user-wrap
  */
@@ -186,7 +186,7 @@ class UserWrapperCommands implements ContainerInjectionInterface {
   }
 
   /**
-   * Perform the swap before running the command.
+   * Perform the swap before running the command, when the option is required.
    *
    * @hook pre-command @islandora-drush-utils-required-user-wrap
    */
@@ -212,7 +212,7 @@ class UserWrapperCommands implements ContainerInjectionInterface {
   }
 
   /**
-   * Swap back after running the command.
+   * Swap back after running the command, when the option is required.
    *
    * @hook post-command @islandora-drush-utils-required-user-wrap
    */

--- a/src/Drush/Commands/UserWrapperCommands.php
+++ b/src/Drush/Commands/UserWrapperCommands.php
@@ -73,6 +73,17 @@ class UserWrapperCommands implements ContainerInjectionInterface {
   }
 
   /**
+   * Command validation callback; `--user` is required, so check for it.
+   *
+   * @hook validate @islandora-drush-utils-required-user-wrap
+   */
+  public function requiredUserCheck(CommandData $commandData) {
+    if (!$commandData->input()->getOption('user')) {
+      return new CommandError('Command requires "--user"; however, it was not passed to the command.');
+    }
+  }
+
+  /**
    * Add the option to the command.
    *
    * @hook option @islandora-drush-utils-user-wrap
@@ -83,6 +94,20 @@ class UserWrapperCommands implements ContainerInjectionInterface {
       'u',
       InputOption::VALUE_REQUIRED,
       'The Drupal user as whom to run the command.'
+    );
+  }
+
+  /**
+   * Add the option to the command.
+   *
+   * @hook option @islandora-drush-utils-required-user-wrap
+   */
+  public function requiredUserOption(Command $command, AnnotationData $annotationData) {
+    $command->addOption(
+      'user',
+      'u',
+      InputOption::VALUE_REQUIRED,
+      'The Drupal user as whom to run the command. NOTE: This option is required for this command.'
     );
   }
 
@@ -102,6 +127,7 @@ class UserWrapperCommands implements ContainerInjectionInterface {
    * Ensure the user provided is valid.
    *
    * @hook validate @islandora-drush-utils-user-wrap
+   * @hook validate @islandora-drush-utils-required-user-wrap
    */
   public function userExists(CommandData $commandData) {
     $input = $commandData->input();
@@ -115,7 +141,7 @@ class UserWrapperCommands implements ContainerInjectionInterface {
     $user_storage = $this->entityTypeManager->getStorage('user');
     if (is_numeric($user)) {
       $this->logDebug('"user" appears to be numeric; loading as-is');
-      $this->user = $user_storage->load($user);
+      $this->user = $user_storage->load($user) ?? FALSE;
     }
     else {
       $this->logDebug('"user" is non-numeric; assuming it is a name');
@@ -141,6 +167,7 @@ class UserWrapperCommands implements ContainerInjectionInterface {
    * Perform the swap before running the command.
    *
    * @hook pre-command @islandora-drush-utils-user-wrap
+   * @hook pre-command @islandora-drush-utils-required-user-wrap
    */
   public function switchUser(CommandData $commandData) {
     $this->logDebug('pre-command');
@@ -155,6 +182,7 @@ class UserWrapperCommands implements ContainerInjectionInterface {
    * Swap back after running the command.
    *
    * @hook post-command @islandora-drush-utils-user-wrap
+   * @hook post-command @islandora-drush-utils-required-user-wrap
    */
   public function unswitch($result, CommandData $commandData) {
     $this->logDebug('post-command');

--- a/src/Drush/Commands/UserWrapperCommands.php
+++ b/src/Drush/Commands/UserWrapperCommands.php
@@ -127,7 +127,6 @@ class UserWrapperCommands implements ContainerInjectionInterface {
    * Ensure the user provided is valid.
    *
    * @hook validate @islandora-drush-utils-user-wrap
-   * @hook validate @islandora-drush-utils-required-user-wrap
    */
   public function userExists(CommandData $commandData) {
     $input = $commandData->input();
@@ -164,10 +163,18 @@ class UserWrapperCommands implements ContainerInjectionInterface {
   }
 
   /**
+   * Ensure the required user provided is valid.
+   *
+   * @hook validate @islandora-drush-utils-required-user-wrap
+ */
+  public function requiredUserExists(CommandData $commandData) {
+    return $this->userExists($commandData);
+  }
+
+  /**
    * Perform the swap before running the command.
    *
    * @hook pre-command @islandora-drush-utils-user-wrap
-   * @hook pre-command @islandora-drush-utils-required-user-wrap
    */
   public function switchUser(CommandData $commandData) {
     $this->logDebug('pre-command');
@@ -179,10 +186,18 @@ class UserWrapperCommands implements ContainerInjectionInterface {
   }
 
   /**
+   * Perform the swap before running the command.
+   *
+   * @hook pre-command @islandora-drush-utils-required-user-wrap
+   */
+  public function requiredSwitchUser(CommandData $commandData) {
+    return $this->switchUser($commandData);
+  }
+
+  /**
    * Swap back after running the command.
    *
    * @hook post-command @islandora-drush-utils-user-wrap
-   * @hook post-command @islandora-drush-utils-required-user-wrap
    */
   public function unswitch($result, CommandData $commandData) {
     $this->logDebug('post-command');
@@ -194,6 +209,15 @@ class UserWrapperCommands implements ContainerInjectionInterface {
     }
 
     return $result;
+  }
+
+  /**
+   * Swap back after running the command.
+   *
+   * @hook post-command @islandora-drush-utils-required-user-wrap
+   */
+  public function requiredUnswitch($result, CommandData $commandData) {
+    return $this->unswitch($result, $commandData);
   }
 
 }

--- a/src/Drush/Commands/UserWrapperCommands.php
+++ b/src/Drush/Commands/UserWrapperCommands.php
@@ -166,7 +166,7 @@ class UserWrapperCommands implements ContainerInjectionInterface {
    * Ensure the required user provided is valid, when the option is required.
    *
    * @hook validate @islandora-drush-utils-required-user-wrap
- */
+   */
   public function requiredUserExists(CommandData $commandData) {
     return $this->userExists($commandData);
   }


### PR DESCRIPTION
Commands wanting to require the `--user` option can use the `@islandora-drush-utils-required-user-wrap` annotation, instead of `@islandora-drush-utils-user-wrap`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Several Drush commands now require an explicit --user option and enforce its presence.
  * New pre- and post-command hooks automatically apply and revert the user context for these required commands.

* **Bug Fixes**
  * Improved user validation and lookup to handle numeric and missing user inputs more reliably.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->